### PR TITLE
feat: migrate to influxdb3-management-go v1 cloud package

### DIFF
--- a/docs/data-sources/token.md
+++ b/docs/data-sources/token.md
@@ -28,6 +28,7 @@ Gets a database token. Use this data source to retrieve information about a data
 - `description` (String) The description of the database token.
 - `expires_at` (String) The date and time that the database token expires, if applicable. Uses RFC3339 format.
 - `permissions` (Attributes Set) The list of permissions the database token allows. (see [below for nested schema](#nestedatt--permissions))
+- `revoked_at` (String) The date and time that the database token was revoked, if applicable. Uses RFC3339 format.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/docs/data-sources/tokens.md
+++ b/docs/data-sources/tokens.md
@@ -32,6 +32,7 @@ Read-Only:
 - `expires_at` (String) The date and time that the database token expires, if applicable. Uses RFC3339 format.
 - `id` (String) The ID of the database token.
 - `permissions` (Attributes Set) The set of permissions the database token allows. (see [below for nested schema](#nestedatt--tokens--permissions))
+- `revoked_at` (String) The date and time that the database token was revoked, if applicable. Uses RFC3339 format.
 
 <a id="nestedatt--tokens--permissions"></a>
 ### Nested Schema for `tokens.permissions`

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -31,6 +31,7 @@ Creates and manages a token and returns the generated database token. Use this r
 - `cluster_id` (String) The ID of the cluster that the database token belongs to.
 - `created_at` (String) The date and time that the database token was created. Uses RFC3339 format.
 - `id` (String) The ID of the database token.
+- `revoked_at` (String) The date and time that the database token was revoked, if applicable. Uses RFC3339 format.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/thulasirajkomminar/influxdb3-management-go v0.6.0
+	github.com/thulasirajkomminar/influxdb3-management-go v1.0.0
 )
 
 require (
@@ -61,7 +61,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/oapi-codegen/runtime v1.4.1 // indirect
+	github.com/oapi-codegen/runtime v1.4.2 // indirect
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
-github.com/oapi-codegen/runtime v1.4.1 h1:9nwLoI+KrWxzbBcp0jO/R8uXqbik/HUyCvPeU68Y/qo=
-github.com/oapi-codegen/runtime v1.4.1/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
+github.com/oapi-codegen/runtime v1.4.2 h1:GMxFVYLzoYLua+/KvzgSphkyK1lLTReQI9Vf4hvATKE=
+github.com/oapi-codegen/runtime v1.4.2/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
@@ -207,8 +207,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/thulasirajkomminar/influxdb3-management-go v0.6.0 h1:O9PwjaIolJYZpg24ma8kElt8G8TKn0RChasmR2uTJxY=
-github.com/thulasirajkomminar/influxdb3-management-go v0.6.0/go.mod h1:wtV7y8bdrDWr0rnLTayrmwqMuu/8hMvcrR37Mixkdvk=
+github.com/thulasirajkomminar/influxdb3-management-go v1.0.0 h1:st/UqMdGcJm4Nv3La+HbVR5GE0DpikghLLKwnWM7y4Q=
+github.com/thulasirajkomminar/influxdb3-management-go v1.0.0/go.mod h1:+L7vOcxf1LRQxJjpfi/l2PQRR9O1yMnXasw/CIBu15U=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/database_data_source.go
+++ b/internal/provider/database_data_source.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -22,9 +22,9 @@ func NewDatabaseDataSource() datasource.DataSource {
 
 // DatabasesDataSource is the data source implementation.
 type DatabaseDataSource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // Metadata returns the data source type name.

--- a/internal/provider/database_model.go
+++ b/internal/provider/database_model.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // DatabaseModel maps InfluxDB database schema data.
@@ -45,14 +45,14 @@ type bucketPartitionValue struct {
 
 // buildPartitionTemplate converts partition template parts from the Terraform
 // model into the API request representation.
-func buildPartitionTemplate(parts []DatabasePartitionTemplateModel) ([]influxdb3.ClusterDatabasePartitionTemplatePart, error) {
-	partitionTemplates := []influxdb3.ClusterDatabasePartitionTemplatePart{}
+func buildPartitionTemplate(parts []DatabasePartitionTemplateModel) ([]influxdb3cloud.ClusterDatabasePartitionTemplatePart, error) {
+	partitionTemplates := []influxdb3cloud.ClusterDatabasePartitionTemplatePart{}
 	for _, pt := range parts {
-		t := influxdb3.ClusterDatabasePartitionTemplatePart{}
+		t := influxdb3cloud.ClusterDatabasePartitionTemplatePart{}
 		switch pt.Type.ValueString() {
 		case "time":
-			timeTemplate := influxdb3.ClusterDatabasePartitionTemplatePartTimeFormat{
-				Type:  (*influxdb3.ClusterDatabasePartitionTemplatePartTimeFormatType)(pt.Type.ValueStringPointer()),
+			timeTemplate := influxdb3cloud.ClusterDatabasePartitionTemplatePartTimeFormat{
+				Type:  (*influxdb3cloud.ClusterDatabasePartitionTemplatePartTimeFormatType)(pt.Type.ValueStringPointer()),
 				Value: pt.Value.ValueStringPointer(),
 			}
 
@@ -60,8 +60,8 @@ func buildPartitionTemplate(parts []DatabasePartitionTemplateModel) ([]influxdb3
 				return nil, fmt.Errorf("failed to merge time template: %w", err)
 			}
 		case "tag":
-			tagTemplate := influxdb3.ClusterDatabasePartitionTemplatePartTagValue{
-				Type:  (*influxdb3.ClusterDatabasePartitionTemplatePartTagValueType)(pt.Type.ValueStringPointer()),
+			tagTemplate := influxdb3cloud.ClusterDatabasePartitionTemplatePartTagValue{
+				Type:  (*influxdb3cloud.ClusterDatabasePartitionTemplatePartTagValueType)(pt.Type.ValueStringPointer()),
 				Value: pt.Value.ValueStringPointer(),
 			}
 
@@ -77,8 +77,8 @@ func buildPartitionTemplate(parts []DatabasePartitionTemplateModel) ([]influxdb3
 				return nil, fmt.Errorf("failed to unmarshal JSON data: %w", err)
 			}
 
-			bucketTemplate := influxdb3.ClusterDatabasePartitionTemplatePartBucket{
-				Type:  (*influxdb3.ClusterDatabasePartitionTemplatePartBucketType)(pt.Type.ValueStringPointer()),
+			bucketTemplate := influxdb3cloud.ClusterDatabasePartitionTemplatePartBucket{
+				Type:  (*influxdb3cloud.ClusterDatabasePartitionTemplatePartBucketType)(pt.Type.ValueStringPointer()),
 				Value: &encodedJSONData,
 			}
 
@@ -131,7 +131,7 @@ func (v partitionTemplateValidator) ValidateList(ctx context.Context, req valida
 	}
 }
 
-func getDatabaseByName(databases influxdb3.GetClusterDatabasesResponse, name string) (*DatabaseModel, error) {
+func getDatabaseByName(databases influxdb3cloud.GetClusterDatabasesResponse, name string) (*DatabaseModel, error) {
 	if databases.JSON200 == nil {
 		return nil, fmt.Errorf("the InfluxDB API returned a success status code without a valid JSON body")
 	}
@@ -158,7 +158,7 @@ func getDatabaseByName(databases influxdb3.GetClusterDatabasesResponse, name str
 	return nil, nil
 }
 
-func getPartitionTemplate(partitionTemplates *influxdb3.ClusterDatabasePartitionTemplate) ([]DatabasePartitionTemplateModel, error) {
+func getPartitionTemplate(partitionTemplates *influxdb3cloud.ClusterDatabasePartitionTemplate) ([]DatabasePartitionTemplateModel, error) {
 	if partitionTemplates == nil {
 		return nil, nil
 	}

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -33,9 +33,9 @@ func NewDatabaseResource() resource.Resource {
 
 // DatabaseResource defines the resource implementation.
 type DatabaseResource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // Metadata returns the resource type name.
@@ -143,7 +143,7 @@ func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateReques
 
 	maxTables := int32(plan.MaxTables.ValueInt64())
 	maxColumnsPerTable := int32(plan.MaxColumnsPerTable.ValueInt64())
-	createDatabaseRequest := influxdb3.CreateClusterDatabaseJSONRequestBody{
+	createDatabaseRequest := influxdb3cloud.CreateClusterDatabaseJSONRequestBody{
 		MaxTables:          &maxTables,
 		MaxColumnsPerTable: &maxColumnsPerTable,
 		Name:               plan.Name.ValueString(),
@@ -278,7 +278,7 @@ func (r *DatabaseResource) Update(ctx context.Context, req resource.UpdateReques
 	if nameChanged {
 		tflog.Debug(ctx, "Name change detected, calling rename database API")
 
-		renameDatabaseRequest := influxdb3.RenameClusterDatabaseJSONRequestBody{
+		renameDatabaseRequest := influxdb3cloud.RenameClusterDatabaseJSONRequestBody{
 			Name: plan.Name.ValueString(),
 		}
 
@@ -328,7 +328,7 @@ func (r *DatabaseResource) Update(ctx context.Context, req resource.UpdateReques
 
 		maxTables := int32(plan.MaxTables.ValueInt64())
 		maxColumnsPerTable := int32(plan.MaxColumnsPerTable.ValueInt64())
-		updateDatabaseRequest := influxdb3.UpdateClusterDatabaseJSONRequestBody{
+		updateDatabaseRequest := influxdb3cloud.UpdateClusterDatabaseJSONRequestBody{
 			MaxTables:          &maxTables,
 			MaxColumnsPerTable: &maxColumnsPerTable,
 			RetentionPeriod:    plan.RetentionPeriod.ValueInt64Pointer(),

--- a/internal/provider/databases_data_source.go
+++ b/internal/provider/databases_data_source.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -22,9 +22,9 @@ func NewDatabasesDataSource() datasource.DataSource {
 
 // DatabasesDataSource is the data source implementation.
 type DatabasesDataSource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // DatabasesDataSourceModel describes the data source data model.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // INFLUXDB3_HOST is the default InfluxDB V3 API host.
@@ -46,9 +46,9 @@ type InfluxDBProviderModel struct {
 }
 
 type providerData struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // Metadata returns the provider type name.
@@ -252,10 +252,10 @@ func (p *InfluxDBProvider) Configure(ctx context.Context, req provider.Configure
 	// the Authorization header.
 	retryClient.HTTPClient.Transport = newLoggingHTTPTransport(token, retryClient.HTTPClient.Transport)
 
-	client, err := influxdb3.NewClientWithResponses(url, influxdb3.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+	client, err := influxdb3cloud.NewClientWithResponses(url, influxdb3cloud.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Accept", "application/json")
 		return nil
-	}), influxdb3.WithHTTPClient(retryClient.StandardClient()))
+	}), influxdb3cloud.WithHTTPClient(retryClient.StandardClient()))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create InfluxDB V3 Client",

--- a/internal/provider/table_resource.go
+++ b/internal/provider/table_resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -30,9 +30,9 @@ func NewTableResource() resource.Resource {
 
 // TableResource defines the resource implementation.
 type TableResource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // TableModel maps InfluxDB database table schema data.
@@ -135,7 +135,7 @@ func (r *TableResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Generate API request body from plan
-	createTableRequest := influxdb3.CreateClusterDatabaseTableJSONRequestBody{
+	createTableRequest := influxdb3cloud.CreateClusterDatabaseTableJSONRequestBody{
 		Name: plan.Name.ValueString(),
 	}
 
@@ -221,7 +221,7 @@ func (r *TableResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	if !plan.Name.Equal(state.Name) {
-		renameTableRequest := influxdb3.RenameClusterDatabaseTableJSONRequestBody{
+		renameTableRequest := influxdb3cloud.RenameClusterDatabaseTableJSONRequestBody{
 			Name: plan.Name.ValueString(),
 		}
 

--- a/internal/provider/token_data_source.go
+++ b/internal/provider/token_data_source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -25,9 +25,9 @@ func NewTokenDataSource() datasource.DataSource {
 
 // TokensDataSource is the data source implementation.
 type TokenDataSource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // Metadata returns the data source type name.
@@ -87,6 +87,11 @@ func (d *TokenDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 						},
 					},
 				},
+			},
+			"revoked_at": schema.StringAttribute{
+				CustomType:  timetypes.RFC3339Type{},
+				Computed:    true,
+				Description: "The date and time that the database token was revoked, if applicable. Uses RFC3339 format.",
 			},
 		},
 	}
@@ -156,6 +161,7 @@ func (d *TokenDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	state.Id = types.StringValue(readToken.Id.String())
 	state.Permissions = getPermissions(readToken.Permissions)
 	state.ExpiresAt = timetypes.NewRFC3339TimePointerValue(readToken.ExpiresAt)
+	state.RevokedAt = timetypes.NewRFC3339TimePointerValue(readToken.RevokedAt)
 
 	// Set state
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/token_model.go
+++ b/internal/provider/token_model.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // TokenModel maps InfluxDB database token schema data.
@@ -21,6 +21,7 @@ type TokenModel struct {
 	ExpiresAt   timetypes.RFC3339      `tfsdk:"expires_at"`
 	Id          types.String           `tfsdk:"id"`
 	Permissions []TokenPermissionModel `tfsdk:"permissions"`
+	RevokedAt   timetypes.RFC3339      `tfsdk:"revoked_at"`
 }
 
 // TokenPermissionModel maps InfluxDB database token permission schema data.
@@ -56,7 +57,30 @@ func (v rfc3339NoSubsecondsValidator) ValidateString(ctx context.Context, req va
 	}
 }
 
-func getPermissions(permissions []influxdb3.DatabaseTokenPermission) []TokenPermissionModel {
+func buildPermissions(permissions []TokenPermissionModel) ([]influxdb3cloud.DatabaseTokenPermission, error) {
+	var permissionsRequest []influxdb3cloud.DatabaseTokenPermission
+	for _, permission := range permissions {
+		resource := influxdb3cloud.DatabaseTokenPermissionResource{}
+
+		var err error
+		if permission.Resource.ValueString() == string(influxdb3cloud.Asterisk) {
+			err = resource.FromDatabaseTokenResourceAllDatabases(influxdb3cloud.Asterisk)
+		} else {
+			err = resource.FromClusterDatabaseName(permission.Resource.ValueString())
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		permissionsRequest = append(permissionsRequest, influxdb3cloud.DatabaseTokenPermission{
+			Action:   permission.Action.ValueStringPointer(),
+			Resource: &resource,
+		})
+	}
+	return permissionsRequest, nil
+}
+
+func getPermissions(permissions []influxdb3cloud.DatabaseTokenPermission) []TokenPermissionModel {
 	permissionsState := []TokenPermissionModel{}
 	for _, permission := range permissions {
 		resource, _ := permission.Resource.AsClusterDatabaseName()

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -31,9 +31,9 @@ func NewTokenResource() resource.Resource {
 
 // TokenResource defines the resource implementation.
 type TokenResource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // Metadata returns the resource type name.
@@ -109,6 +109,11 @@ func (r *TokenResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					},
 				},
 			},
+			"revoked_at": schema.StringAttribute{
+				CustomType:  timetypes.RFC3339Type{},
+				Computed:    true,
+				Description: "The date and time that the database token was revoked, if applicable. Uses RFC3339 format.",
+			},
 		},
 	}
 }
@@ -124,27 +129,16 @@ func (r *TokenResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Generate API request body from plan
-	var permissionsRequest []influxdb3.DatabaseTokenPermission
-	for _, permission := range plan.Permissions {
-		resource := influxdb3.DatabaseTokenPermissionResource{}
-
-		err := resource.FromClusterDatabaseName(permission.Resource.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Validation error. Ensure the Resource is in the correct format.",
-				err.Error(),
-			)
-			return
-		}
-
-		permission := influxdb3.DatabaseTokenPermission{
-			Action:   permission.Action.ValueStringPointer(),
-			Resource: &resource,
-		}
-		permissionsRequest = append(permissionsRequest, permission)
+	permissionsRequest, err := buildPermissions(plan.Permissions)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Validation error. Ensure the Resource is in the correct format.",
+			err.Error(),
+		)
+		return
 	}
 
-	createTokenRequest := influxdb3.CreateDatabaseTokenJSONRequestBody{
+	createTokenRequest := influxdb3cloud.CreateDatabaseTokenJSONRequestBody{
 		Description: plan.Description.ValueString(),
 		Permissions: &permissionsRequest,
 	}
@@ -192,6 +186,7 @@ func (r *TokenResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.Id = types.StringValue(createToken.Id.String())
 	plan.Permissions = getPermissions(createToken.Permissions)
 	plan.ExpiresAt = timetypes.NewRFC3339TimePointerValue(createToken.ExpiresAt)
+	plan.RevokedAt = timetypes.NewRFC3339TimePointerValue(createToken.RevokedAt)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -262,6 +257,7 @@ func (r *TokenResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.Id = types.StringValue(readToken.Id.String())
 	state.Permissions = getPermissions(readToken.Permissions)
 	state.ExpiresAt = timetypes.NewRFC3339TimePointerValue(readToken.ExpiresAt)
+	state.RevokedAt = timetypes.NewRFC3339TimePointerValue(readToken.RevokedAt)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -291,27 +287,16 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Generate API request body from plan
-	var permissionsRequest []influxdb3.DatabaseTokenPermission
-	for _, permission := range plan.Permissions {
-		resource := influxdb3.DatabaseTokenPermissionResource{}
-
-		err := resource.FromClusterDatabaseName(permission.Resource.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Validation error. Ensure the Resource is in the correct format.",
-				err.Error(),
-			)
-			return
-		}
-
-		permission := influxdb3.DatabaseTokenPermission{
-			Action:   permission.Action.ValueStringPointer(),
-			Resource: &resource,
-		}
-		permissionsRequest = append(permissionsRequest, permission)
+	permissionsRequest, err := buildPermissions(plan.Permissions)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Validation error. Ensure the Resource is in the correct format.",
+			err.Error(),
+		)
+		return
 	}
 
-	updateTokenRequest := influxdb3.UpdateDatabaseTokenJSONRequestBody{
+	updateTokenRequest := influxdb3cloud.UpdateDatabaseTokenJSONRequestBody{
 		Description: plan.Description.ValueStringPointer(),
 		Permissions: &permissionsRequest,
 	}
@@ -350,6 +335,7 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	plan.Id = types.StringValue(updateToken.Id.String())
 	plan.Permissions = getPermissions(updateToken.Permissions)
 	plan.ExpiresAt = timetypes.NewRFC3339TimePointerValue(updateToken.ExpiresAt)
+	plan.RevokedAt = timetypes.NewRFC3339TimePointerValue(updateToken.RevokedAt)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/tokens_data_source.go
+++ b/internal/provider/tokens_data_source.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -24,9 +24,9 @@ func NewTokensDataSource() datasource.DataSource {
 
 // TokensDataSource is the data source implementation.
 type TokensDataSource struct {
-	accountID influxdb3.UuidV4
-	client    influxdb3.ClientWithResponses
-	clusterID influxdb3.UuidV4
+	accountID influxdb3cloud.UuidV4
+	client    influxdb3cloud.ClientWithResponses
+	clusterID influxdb3cloud.UuidV4
 }
 
 // TokensDataSourceModel describes the data source data model.
@@ -96,6 +96,11 @@ func (d *TokensDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 								},
 							},
 						},
+						"revoked_at": schema.StringAttribute{
+							CustomType:  timetypes.RFC3339Type{},
+							Computed:    true,
+							Description: "The date and time that the database token was revoked, if applicable. Uses RFC3339 format.",
+						},
 					},
 				},
 			},
@@ -159,6 +164,7 @@ func (d *TokensDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 			ExpiresAt:   timetypes.NewRFC3339TimePointerValue(token.ExpiresAt),
 			Id:          types.StringValue(token.Id.String()),
 			Permissions: getPermissions(token.Permissions),
+			RevokedAt:   timetypes.NewRFC3339TimePointerValue(token.RevokedAt),
 		}
 
 		state.Tokens = append(state.Tokens, tokenState)

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/thulasirajkomminar/influxdb3-management-go"
+	"github.com/thulasirajkomminar/influxdb3-management-go/cloud"
 )
 
 // formatErrorResponse formats the error response from the InfluxDB API.
@@ -19,7 +19,7 @@ func formatErrorResponse(rsp any, statusCode int) string {
 	}
 
 	if field := v.FieldByName("JSON" + strconv.Itoa(statusCode)); field.IsValid() {
-		if errorDetail, ok := field.Interface().(*influxdb3.Error); ok && errorDetail != nil {
+		if errorDetail, ok := field.Interface().(*influxdb3cloud.Error); ok && errorDetail != nil {
 			return fmt.Sprintf("HTTP Status Code: %d\nError Code: %d\nError Message: %s\n", statusCode, errorDetail.Code, errorDetail.Message)
 		}
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Upgrades the management SDK from v0.6.0 to v1.0.0, which splits the former root package into per-variant packages (cloud, core, enterprise). This provider now imports the cloud (Cloud Dedicated) package; the API surface is operation-identical, so all call sites are unchanged apart from the package rename.

New functionality wired up from the SDK:

* Add revoked_at (computed, RFC3339) to the influxdb3_token resource and the influxdb3_token / influxdb3_tokens data sources, so tokens revoked outside Terraform surface on refresh.
* Send the * (all-databases) token permission through the SDK's dedicated all-databases union variant instead of the database-name variant. Wire format is unchanged; this future-proofs against name validation being added to the SDK.
* Deduplicate the token permission request building in Create/Update into a shared buildPermissions helper.

Docs regenerated via tfplugindocs. No breaking changes for users; existing states gain the new computed revoked_at attribute on the first plan after upgrading.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc

...
```
